### PR TITLE
Allow "all" domains when configuring session cookie store

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,1 @@
-# TODO
-# Set custom domain
-# https://stackoverflow.com/questions/4060333/what-does-rails-3-session-store-domain-all-really-do
-Rails.application.config.session_store :cookie_store, key: '_devcamp_space_session', domain: 'devcamp.space'
+Rails.application.config.session_store :cookie_store, key: '_devcamp_space_session', domain: :all


### PR DESCRIPTION
Otherwise, it won't be possible to authenticate cross-site requests
from the students' applications (hosted under their own domains) to
the `api.devcamp.space`.

Closes bottega-code-school/devcamp#1243

---

This should fix the problem with authentication from students' domains (I can confirm it works in the local environment under the SSL). However, the change may make authentication "too wide". With this change, you can log in to one student's project, go to another, and still be logged in. I didn't dig deep in the Student Service. Hence, I'm not 100% if this is a problem, i.e., if the application ensures the authenticated "current client" has access to a given resource (like creating some resources for the given client). If it doesn't do this, we would need to somehow demand logging in again on another application even if the student is authenticated in his application. We could achieve it with the following code:

```diff
diff --git a/app/controllers/concerns/authentication_concern.rb b/app/controllers/concerns/authentication_concern.rb
index 132e1bb..680679c 100644
--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -6,8 +6,30 @@ module AuthenticationConcern
   end

   def set_current_client
-    if session[:client_id]
-      @current_client = Client.find(session[:client_id])
+    return unless session[:client_id].present?
+    return unless client = Client.find(session[:client_id])
+    return unless referer_matches_client_domains?(client)
+
+    @current_client = client
+  end
+
+  private
+
+  def client_allowed_hosts(client)
+    client.
+      client_domains.
+      pluck(:url).
+      map { |url| URI.parse(url).try(:host) }.
+      compact
+  end
+
+  def referer_host
+    if request.referer.present?
+      URI.parse(request.referer).host
     end
   end
+
+  def referer_matches_client_domains?(client)
+    client_allowed_hosts(client).include?(referer_host)
+  end
 end
```

Still, I'm not sure if this is the best approach for Student Service. `GET /logged_in` would succeed only if the referer is given and if it was previously added via the client's domains. In other words, the student will need to register his application first and create a relevant `client_domains` record, and the request itself will need to include the referee (this might require testing with Heroku).